### PR TITLE
Add verifiable installer health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ www
 /.claude
 /.spec-workflow
 backups
+.gstack/

--- a/cfg_tpl/xray_client.config.json
+++ b/cfg_tpl/xray_client.config.json
@@ -105,11 +105,17 @@
         "downlinkCapacity": 100,
         "congestion": false,
         "readBufferSize": 2,
-        "writeBufferSize": 2,
-        "header": {
-          "type": "none"
-        },
-        "seed": "${KCP_SEED}"
+        "writeBufferSize": 2
+      },
+      "finalmask": {
+        "udp": [
+          {
+            "type": "mkcp-aes128gcm",
+            "settings": {
+              "password": "${KCP_SEED}"
+            }
+          }
+        ]
       }
     }
   }

--- a/cfg_tpl/xray_config.json
+++ b/cfg_tpl/xray_config.json
@@ -93,8 +93,17 @@
           "downlinkCapacity": 100,
           "congestion": false,
           "readBufferSize": 2,
-          "writeBufferSize": 2,
-          "seed": "${KCP_SEED}"
+          "writeBufferSize": 2
+        },
+        "finalmask": {
+          "udp": [
+            {
+              "type": "mkcp-aes128gcm",
+              "settings": {
+                "password": "${KCP_SEED}"
+              }
+            }
+          ]
         }
       },
       "sniffing": {

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,341 @@ log_warning() {
     echo "[WARNING] $(date '+%Y-%m-%d %H:%M:%S') - $1" >&2
 }
 
+HEALTH_FAILURES=0
+HEALTH_WARNINGS=0
+HEALTH_REPORT_STARTED=0
+
+start_health_report() {
+    if [ "$HEALTH_REPORT_STARTED" -eq 0 ]; then
+        echo "=== Xray-Caddy Install Health Report ==="
+        HEALTH_REPORT_STARTED=1
+    fi
+}
+
+report_pass() {
+    start_health_report
+    printf 'PASS  %-24s %s\n' "$1" "$2"
+}
+
+report_warn() {
+    start_health_report
+    HEALTH_WARNINGS=$((HEALTH_WARNINGS + 1))
+    printf 'WARN  %-24s %s\n' "$1" "$2"
+}
+
+report_fail() {
+    start_health_report
+    HEALTH_FAILURES=$((HEALTH_FAILURES + 1))
+    printf 'FAIL  %-24s %s\n' "$1" "$2"
+}
+
+report_info() {
+    start_health_report
+    printf 'INFO  %-24s %s\n' "$1" "$2"
+}
+
+emit_health_result() {
+    start_health_report
+    if [ "$HEALTH_FAILURES" -gt 0 ]; then
+        echo "RESULT FAIL"
+    else
+        echo "RESULT PASS"
+    fi
+    echo "WARNINGS $HEALTH_WARNINGS"
+}
+
+redact_sensitive_output() {
+    local text
+    text=$(cat)
+    for secret in "${PRIVATE_KEY:-}" "${PUBLIC_KEY:-}" "${UUID:-}" "${KCP_SEED:-}"; do
+        if [ -n "$secret" ]; then
+            text="${text//$secret/<hidden>}"
+        fi
+    done
+    printf '%s\n' "$text"
+}
+
+print_journal_summary() {
+    local unit="$1"
+    log_error "${unit} 最近日志（已脱敏）:"
+    journalctl -u "$unit" -n 30 --no-pager 2>&1 | redact_sensitive_output | while IFS= read -r line; do
+        log_error "  $line"
+    done
+}
+
+require_executable() {
+    local label="$1"
+    local path="$2"
+    if [ -x "$path" ]; then
+        report_pass "binary:$label" "$path"
+    else
+        report_fail "binary:$label" "$path missing or not executable; reinstall or check permissions"
+    fi
+}
+
+validate_xray_config() {
+    local output
+    if output=$("$XRAY_EXE" run -test -c "$XRAY_CONFIG_OUTPUT_PATH" 2>&1); then
+        report_pass "config:xray" "$XRAY_CONFIG_OUTPUT_PATH"
+    else
+        report_fail "config:xray" "$XRAY_CONFIG_OUTPUT_PATH invalid; run xray run -test for details"
+        printf '%s\n' "$output" | redact_sensitive_output | while IFS= read -r line; do
+            log_error "  $line"
+        done
+    fi
+}
+
+validate_caddy_config() {
+    local output
+    if output=$(/usr/local/bin/caddy validate --config "$CADDY_CONFIG_OUTPUT_PATH" 2>&1); then
+        report_pass "config:caddy" "$CADDY_CONFIG_OUTPUT_PATH"
+    else
+        report_fail "config:caddy" "$CADDY_CONFIG_OUTPUT_PATH invalid; run caddy validate for details"
+        printf '%s\n' "$output" | redact_sensitive_output | while IFS= read -r line; do
+            log_error "  $line"
+        done
+    fi
+}
+
+stop_pid_file_process() {
+    local pid_file="$1"
+    local expected="$2"
+    local label="$3"
+    local pid=""
+    local cmdline=""
+
+    [ -f "$pid_file" ] || return 0
+    pid=$(cat "$pid_file" 2>/dev/null || true)
+    if [[ "$pid" =~ ^[0-9]+$ ]] && ps -p "$pid" >/dev/null 2>&1; then
+        cmdline=$(ps -p "$pid" -o args= 2>/dev/null || true)
+        if [[ "$cmdline" == *"$expected"* ]]; then
+            log_info "停止旧的 $label fallback 进程 (PID: $pid)"
+            kill "$pid" 2>/dev/null || true
+        fi
+    fi
+    rm -f "$pid_file"
+}
+
+kill_matching_processes() {
+    local expected="$1"
+    local label="$2"
+    local pid=""
+    local cmdline=""
+
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        cmdline=$(ps -p "$pid" -o args= 2>/dev/null || true)
+        if [[ "$cmdline" == *"$expected"* ]]; then
+            log_info "停止旧的 $label fallback 进程 (PID: $pid)"
+            kill "$pid" 2>/dev/null || true
+        fi
+    done < <(pgrep -f "$expected" 2>/dev/null || true)
+}
+
+stop_existing_runtime() {
+    systemctl stop caddy.service xray.service 2>/dev/null || true
+    mkdir -p /var/run/xray-caddy
+    stop_pid_file_process "/var/run/xray-caddy/caddy.pid" "/usr/local/bin/caddy run --config /etc/caddy/caddy.json" "Caddy"
+    stop_pid_file_process "/var/run/xray-caddy/xray.pid" "/usr/local/bin/xray run -c /etc/xray/config.json" "Xray"
+    kill_matching_processes "/usr/local/bin/caddy run --config /etc/caddy/caddy.json" "Caddy"
+    kill_matching_processes "/usr/local/bin/xray run -c /etc/xray/config.json" "Xray"
+}
+
+write_systemd_units() {
+    cat > /etc/systemd/system/caddy.service << 'EOF'
+[Unit]
+Description=Caddy HTTP/2 web server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart=/usr/local/bin/caddy run --config /etc/caddy/caddy.json
+ExecReload=/bin/kill -USR1 $MAINPID
+Restart=always
+RestartSec=10s
+LimitNOFILE=4096
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    cat > /etc/systemd/system/xray.service << 'EOF'
+[Unit]
+Description=Xray Service
+Documentation=https://github.com/XTLS/Xray-core
+After=network.target nss-lookup.target
+
+[Service]
+User=root
+Group=root
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+ExecStart=/usr/local/bin/xray run -c /etc/xray/config.json
+Restart=on-failure
+RestartSec=10s
+LimitNOFILE=infinity
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+wait_for_unit() {
+    local unit="$1"
+    local attempt
+    for attempt in 1 2 3 4 5 6 7 8 9 10; do
+        if systemctl is-active --quiet "$unit"; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+check_systemd_unit() {
+    local label="$1"
+    local unit="$2"
+    local active=""
+    local enabled=""
+
+    wait_for_unit "$unit" || true
+    active=$(systemctl is-active "$unit" 2>/dev/null || true)
+    enabled=$(systemctl is-enabled "$unit" 2>/dev/null || true)
+
+    if [ "$active" = "active" ] && [ "$enabled" = "enabled" ]; then
+        report_pass "systemd:$label" "$active $enabled"
+    else
+        report_fail "systemd:$label" "active=$active enabled=$enabled; inspect journalctl -u $unit"
+        print_journal_summary "$unit"
+    fi
+}
+
+configure_systemd_services() {
+    if ! command -v systemctl >/dev/null 2>&1; then
+        report_fail "systemd" "systemctl missing; this installer requires a Debian/Ubuntu systemd VPS"
+        return 1
+    fi
+
+    stop_existing_runtime
+    write_systemd_units
+
+    if ! systemctl daemon-reload; then
+        report_fail "systemd:daemon" "daemon-reload failed; inspect systemctl status and unit files"
+        return 1
+    fi
+
+    if ! systemctl enable caddy.service xray.service >/dev/null; then
+        report_fail "systemd:enable" "enable failed; inspect systemctl status caddy.service xray.service"
+        return 1
+    fi
+
+    if ! systemctl restart caddy.service xray.service; then
+        log_warning "systemd restart 返回失败，健康报告将读取服务状态和日志。"
+    fi
+
+    check_systemd_unit "xray" "xray.service"
+    check_systemd_unit "caddy" "caddy.service"
+}
+
+listener_lines() {
+    local proto="$1"
+    local port="$2"
+    if [ "$proto" = "tcp" ]; then
+        ss -H -lntp 2>/dev/null | awk -v port="$port" '$4 ~ ":" port "$" {print}'
+    else
+        ss -H -lnup 2>/dev/null | awk -v port="$port" '$4 ~ ":" port "$" {print}'
+    fi
+}
+
+check_listener() {
+    local proto="$1"
+    local port="$2"
+    local process="$3"
+    local output=""
+
+    if ! command -v ss >/dev/null 2>&1; then
+        report_fail "listener:$proto/$port" "ss command missing; install iproute2 to verify local listeners"
+        return
+    fi
+
+    output=$(listener_lines "$proto" "$port")
+    if [ -n "$output" ] && printf '%s\n' "$output" | grep -qi "$process"; then
+        report_pass "listener:$proto/$port" "$process"
+    else
+        report_fail "listener:$proto/$port" "expected $process listener missing; check service logs and port conflicts"
+    fi
+}
+
+check_client_info_file() {
+    local file="/etc/xray/client_config_info.txt"
+    local mode=""
+
+    if [ ! -f "$file" ]; then
+        report_fail "client_info" "$file missing; rerun install to regenerate client parameters"
+        return
+    fi
+
+    mode=$(stat -c '%a' "$file" 2>/dev/null || echo "")
+    if [ -z "$mode" ] || [ $((8#$mode & 077)) -ne 0 ]; then
+        report_fail "client_info" "$file permissions are ${mode:-unknown}; run chmod 600 $file"
+        return
+    fi
+
+    if ! grep -q 'PublicKey' "$file"; then
+        report_fail "client_info" "$file lacks PublicKey; rerun install and check x25519 output"
+        return
+    fi
+
+    report_info "client_info" "$file"
+}
+
+check_external_https() {
+    local output=""
+
+    if ! command -v curl >/dev/null 2>&1; then
+        report_warn "external:https" "curl missing, skipped; check DNS/firewall/security group manually"
+        return
+    fi
+
+    if output=$(curl --max-time 5 --silent --show-error --output /dev/null --write-out '%{http_code}' "https://$DOMAIN/" 2>&1); then
+        report_pass "external:https" "HTTP $output"
+    else
+        report_warn "external:https" "$output; check DNS/firewall/security group/certificate issuance"
+    fi
+}
+
+run_install_health_checks() {
+    log_info "正在执行安装健康检查..."
+    HEALTH_FAILURES=0
+    HEALTH_WARNINGS=0
+    HEALTH_REPORT_STARTED=0
+
+    require_executable "xray" "$XRAY_EXE"
+    require_executable "caddy" "/usr/local/bin/caddy"
+    validate_xray_config
+    validate_caddy_config
+
+    if [ "$HEALTH_FAILURES" -gt 0 ]; then
+        emit_health_result
+        return 1
+    fi
+
+    configure_systemd_services || true
+    check_listener "tcp" "80" "caddy"
+    check_listener "tcp" "443" "xray"
+    check_listener "udp" "443" "caddy"
+    check_listener "udp" "2052" "xray"
+    check_external_https
+    check_client_info_file
+    emit_health_result
+
+    [ "$HEALTH_FAILURES" -eq 0 ]
+}
+
 # --- Cleanup function for temporary files ---
 cleanup_temp_files() {
     if [ -d "./app/temp" ]; then
@@ -234,9 +569,11 @@ log_info "UUID 生成完成（出于安全考虑不显示具体值）"
 
 # --- 5. Generate Private/Public Keys for Xray ---
 log_info "正在生成 Xray X25519 密钥对..."
-# 捕获命令执行的完整输出和错误信息
-KEY_OUTPUT=$("$XRAY_EXE" x25519 2>&1)
-KEY_EXIT_CODE=$?
+if KEY_OUTPUT=$("$XRAY_EXE" x25519 2>&1); then
+    KEY_EXIT_CODE=0
+else
+    KEY_EXIT_CODE=$?
+fi
 
 if [ $KEY_EXIT_CODE -ne 0 ]; then
     log_error "Xray x25519 命令执行失败，退出码: $KEY_EXIT_CODE"
@@ -246,24 +583,47 @@ if [ $KEY_EXIT_CODE -ne 0 ]; then
     exit 1
 fi
 
-log_info "X25519 密钥对生成完成（出于安全考虑不显示具体值）"
+log_info "X25519 命令执行完成，正在解析输出..."
 
-# Xray 不同版本的 x25519 命令输出格式可能不同
-# 旧版本格式: "Private key:" 和 "Public key:"
-# 新版本格式: "PrivateKey:" 和 "Password:" (其中 Password 是公钥)
-PRIVATE_KEY=$(echo "$KEY_OUTPUT" | grep -E "(Private key:|PrivateKey:)" | awk '{print $NF}')
-PUBLIC_KEY=$(echo "$KEY_OUTPUT" | grep -E "(Public key:|Password:)" | awk '{print $NF}')
+extract_x25519_value() {
+    local key_type="$1"
+    local raw_output="$2"
+    printf '%s\n' "$raw_output" | awk -F ':' -v key_type="$key_type" '
+        {
+            label = tolower($1)
+            gsub(/[[:space:]]+/, "", label)
+        }
+        key_type == "private" && label == "privatekey" {
+            sub(/^[^:]*:[[:space:]]*/, "")
+            print
+            exit
+        }
+        key_type == "public" && (label == "publickey" || label == "password" || label == "password(publickey)") {
+            sub(/^[^:]*:[[:space:]]*/, "")
+            print
+            exit
+        }
+    '
+}
+
+PRIVATE_KEY=$(extract_x25519_value private "$KEY_OUTPUT" || true)
+PUBLIC_KEY=$(extract_x25519_value public "$KEY_OUTPUT" || true)
 
 # 检查是否成功提取了密钥
 if [ -z "$PRIVATE_KEY" ] || [ -z "$PUBLIC_KEY" ]; then
     log_error "无法从命令输出中提取密钥。"
-    log_error "命令输出: $KEY_OUTPUT"
-    log_error "尝试直接执行命令以查看详细输出:"
-    "$XRAY_EXE" x25519
+    log_error "命令输出标签如下（已隐藏密钥值）:"
+    printf '%s\n' "$KEY_OUTPUT" | while IFS= read -r line; do
+        if [[ "$line" == *:* ]]; then
+            log_error "  ${line%%:*}: <hidden>"
+        else
+            log_error "  <non key-value output hidden>"
+        fi
+    done
     exit 1
 fi
 
-log_info "X25519 密钥对生成完成（公钥将在安装完成后显示）"
+log_info "X25519 密钥对生成完成，客户端参数将保存到 /etc/xray/client_config_info.txt"
 
 # --- 7. Configure Xray-core ---
 log_info "正在配置 Xray-core (config.json)..."
@@ -341,7 +701,12 @@ ln -sf "$CURRENT_SCRIPT_DIR/main.sh" /usr/local/bin/xraycaddy
 chmod +x /usr/local/bin/xraycaddy
 log_info "快捷命令 'xraycaddy' 已创建完成"
 
-# 注意：临时文件清理由 EXIT trap 自动处理（见第 41 行）
+if ! run_install_health_checks; then
+    log_error "安装健康检查失败，请按报告中的 FAIL 项处理。"
+    exit 1
+fi
+
+# 注意：临时文件清理由 EXIT trap 自动处理
 
 log_info "---------------------------------------------------------------------"
 log_info "安装和配置完成!"
@@ -363,8 +728,8 @@ log_info "  配置信息: /etc/xray/config_info.txt"
 log_info "  客户端信息: /etc/xray/client_config_info.txt"
 log_info ""
 log_info "快捷命令:"
-log_info "  管理服务: xraycaddy (显示菜单)"
-log_info "  启动服务: xraycaddy start"
+log_info "  管理菜单: xraycaddy"
+log_info "  systemd 状态: systemctl status caddy.service xray.service"
 log_info ""
 log_info "⚠️  重要提醒:"
 log_info "  - 所有敏感配置信息已保存到 /etc/xray/ 目录"

--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ redact_sensitive_output() {
     text=$(cat)
     for secret in "${PRIVATE_KEY:-}" "${PUBLIC_KEY:-}" "${UUID:-}" "${KCP_SEED:-}"; do
         if [ -n "$secret" ]; then
-            text="${text//$secret/<hidden>}"
+            text="${text//"$secret"/<hidden>}"
         fi
     done
     printf '%s\n' "$text"
@@ -183,7 +183,7 @@ ExecStart=/usr/local/bin/caddy run --config /etc/caddy/caddy.json
 ExecReload=/bin/kill -USR1 $MAINPID
 Restart=always
 RestartSec=10s
-LimitNOFILE=4096
+LimitNOFILE=infinity
 
 [Install]
 WantedBy=multi-user.target
@@ -328,11 +328,19 @@ check_external_https() {
         return
     fi
 
-    if output=$(curl --max-time 5 --silent --show-error --output /dev/null --write-out '%{http_code}' "https://$DOMAIN/" 2>&1); then
-        report_pass "external:https" "HTTP $output"
-    else
+    if ! output=$(curl --location --max-time 5 --silent --show-error --output /dev/null --write-out '%{http_code}' "https://$DOMAIN/" 2>&1); then
         report_warn "external:https" "$output; check DNS/firewall/security group/certificate issuance"
+        return
     fi
+
+    case "$output" in
+        2*|3*)
+            report_pass "external:https" "HTTP $output"
+            ;;
+        *)
+            report_warn "external:https" "HTTP $output; check DNS/firewall/security group/certificate issuance"
+            ;;
+    esac
 }
 
 run_install_health_checks() {

--- a/main.sh
+++ b/main.sh
@@ -242,6 +242,30 @@ validate_path() {
     fi
 }
 
+systemd_units_ready() {
+    command -v systemctl >/dev/null 2>&1 \
+        && [ -f "/etc/systemd/system/caddy.service" ] \
+        && [ -f "/etc/systemd/system/xray.service" ]
+}
+
+manage_services() {
+    local action="$1"
+    if systemd_units_ready; then
+        systemctl "$action" caddy.service xray.service
+    else
+        log_warning "未找到 systemd unit，使用 service.sh 手动 fallback。"
+        bash "$SCRIPT_DIR/service.sh" "$action"
+    fi
+}
+
+show_systemd_status() {
+    systemctl status caddy.service xray.service --no-pager || true
+}
+
+escape_sed_replacement() {
+    printf '%s' "$1" | sed 's/[&|\\]/\\&/g'
+}
+
 # 主菜单函数
 show_menu() {
     echo "----------------------------------------"
@@ -295,15 +319,8 @@ show_menu() {
                 fi
             fi
 
-            # 询问是否立即启动服务
-            read -r -p "安装已完成，是否立即启动服务? [Y/n]: " start_service
-            start_service=${start_service:-Y}
-            if [[ $start_service =~ ^[Yy]$ ]]; then
-                echo "正在启动服务..."
-                bash "$SCRIPT_DIR/service.sh" start
-            else
-                echo "服务未启动，您可以稍后使用 'bash "$SCRIPT_DIR/service.sh" start' 命令启动服务。"
-            fi
+            echo "安装已完成，服务已由 systemd 托管并完成健康检查。"
+            echo "客户端参数: xraycaddy -> 6，或查看 /etc/xray/client_config_info.txt"
             read -r -p "按回车键继续..."
             ;;
         2)
@@ -348,13 +365,20 @@ show_menu() {
                 echo "正在更新配置并重启服务..."
                 # 调用安装脚本进行配置更新
                 if [[ "$cert_type" == "existing" ]]; then
-                    bash "$SCRIPT_DIR/install.sh" "$domain" "$kcp_seed" "$www_root" "$cert_type" "$cert_path" "$key_path" "$email"
+                    if ! bash "$SCRIPT_DIR/install.sh" "$domain" "$kcp_seed" "$www_root" "$cert_type" "$cert_path" "$key_path" "$email"; then
+                        log_error "配置更新失败，请检查上述错误信息。"
+                        read -r -p "按回车键继续..."
+                        return 1
+                    fi
                 else
-                    bash "$SCRIPT_DIR/install.sh" "$domain" "$kcp_seed" "$www_root" "$cert_type" "" "" "$email"
+                    if ! bash "$SCRIPT_DIR/install.sh" "$domain" "$kcp_seed" "$www_root" "$cert_type" "" "" "$email"; then
+                        log_error "配置更新失败，请检查上述错误信息。"
+                        read -r -p "按回车键继续..."
+                        return 1
+                    fi
                 fi
-                # 重启服务
-                bash "$SCRIPT_DIR/service.sh" restart
-                echo "配置已更新，服务已重启。"
+                echo "配置已更新，服务已由 systemd 重启并完成健康检查。"
+                echo "客户端参数: xraycaddy -> 6，或查看 /etc/xray/client_config_info.txt"
             else
                 echo "操作已取消。"
             fi
@@ -362,14 +386,20 @@ show_menu() {
             ;;
         3)
             echo "正在重启服务..."
-            # 调用service.sh脚本重启服务
-            bash "$SCRIPT_DIR/service.sh" restart
+            if manage_services restart; then
+                echo "服务已重启。"
+            else
+                echo "服务重启失败，请检查上方错误信息。"
+            fi
             read -r -p "按回车键继续..."
             ;;
         4)
             echo "正在停止服务..."
-            # 调用service.sh脚本停止服务
-            bash "$SCRIPT_DIR/service.sh" stop
+            if manage_services stop; then
+                echo "服务已停止。"
+            else
+                echo "服务停止失败，请检查上方错误信息。"
+            fi
             read -r -p "按回车键继续..."
             ;;
         5)
@@ -395,12 +425,17 @@ show_menu() {
 
             # 从模板生成配置文件，替换所有占位符
             if [ -f "$CURRENT_DIR/cfg_tpl/xray_client.config.json" ]; then
-                # 使用sed替换配置文件中的所有变量
-                sed -e "s|\${DOMAIN}|$DOMAIN|g" \
-                    -e "s|\${UUID}|$UUID|g" \
-                    -e "s|\${EMAIL}|${EMAIL:-admin@$DOMAIN}|g" \
-                    -e "s|\${PUBLIC_KEY}|$PUBLIC_KEY|g" \
-                    -e "s|\${KCP_SEED}|$KCP_SEED|g" \
+                escaped_domain=$(escape_sed_replacement "$DOMAIN")
+                escaped_uuid=$(escape_sed_replacement "$UUID")
+                escaped_email=$(escape_sed_replacement "${EMAIL:-admin@$DOMAIN}")
+                escaped_public_key=$(escape_sed_replacement "$PUBLIC_KEY")
+                escaped_kcp_seed=$(escape_sed_replacement "$KCP_SEED")
+
+                sed -e "s|\${DOMAIN}|$escaped_domain|g" \
+                    -e "s|\${UUID}|$escaped_uuid|g" \
+                    -e "s|\${EMAIL}|$escaped_email|g" \
+                    -e "s|\${PUBLIC_KEY}|$escaped_public_key|g" \
+                    -e "s|\${KCP_SEED}|$escaped_kcp_seed|g" \
                     "$CURRENT_DIR/cfg_tpl/xray_client.config.json" > "./app/xray_client_config.json"
 
                 echo "客户端配置文件已生成: ./app/xray_client_config.json"
@@ -493,80 +528,43 @@ show_menu() {
             read -r -p "按回车键继续..."
             ;;
         9)
-            echo "正在准备设为开机自启服务..."
+            echo "正在修复 systemd 开机自启服务..."
 
-            # 确保systemd可用
             if ! command -v systemctl &> /dev/null; then
-                echo "错误：systemd不可用，无法设置开机自启。"
+                echo "错误：systemd 不可用，当前安装闭环仅支持常规 Debian/Ubuntu systemd VPS。"
                 read -r -p "按回车键继续..."
                 return
             fi
 
-            # 检查程序是否存在
             if [ ! -f "/usr/local/bin/caddy" ] || [ ! -f "/usr/local/bin/xray" ]; then
                 echo "错误：Xray 或 Caddy 未安装，请先安装服务。"
                 read -r -p "按回车键继续..."
                 return
             fi
 
-            # 创建caddy.service文件
-            cat > /etc/systemd/system/caddy.service << EOF
-[Unit]
-Description=Caddy HTTP/2 web server
-After=network-online.target
-Wants=network-online.target systemd-networkd-wait-online.service
+            if ! systemd_units_ready; then
+                echo "错误：未找到 systemd unit，请重新运行安装流程生成并验证服务配置。"
+                read -r -p "按回车键继续..."
+                return
+            fi
 
-[Service]
-Type=simple
-User=root
-Group=root
-ExecStart=/usr/local/bin/caddy run --config /etc/caddy/caddy.json
-ExecReload=/bin/kill -USR1 \$MAINPID
-Restart=always
-RestartSec=10s
-LimitNOFILE=4096
+            if ! systemctl daemon-reload; then
+                echo "错误：systemd 配置重载失败，请检查 unit 文件。"
+                read -r -p "按回车键继续..."
+                return 1
+            fi
+            if ! systemctl enable caddy.service xray.service; then
+                echo "错误：设置开机自启失败，请检查 systemd 状态。"
+                read -r -p "按回车键继续..."
+                return 1
+            fi
+            if systemctl restart caddy.service xray.service; then
+                echo "服务已设置为开机自启并重新启动。"
+            else
+                echo "服务启动失败，请查看 systemd 状态和日志。"
+            fi
 
-[Install]
-WantedBy=multi-user.target
-EOF
-
-            # 创建xray.service文件
-            cat > /etc/systemd/system/xray.service << EOF
-[Unit]
-Description=Xray Service
-Documentation=https://github.com/XTLS/Xray-core
-After=network.target nss-lookup.target
-
-[Service]
-User=root
-Group=root
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
-AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
-NoNewPrivileges=true
-ExecStart=/usr/local/bin/xray run -c /etc/xray/config.json
-Restart=on-failure
-RestartSec=10s
-LimitNOFILE=infinity
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-            # 重新加载systemd配置
-            systemctl daemon-reload
-
-            # 启用服务开机自启
-            systemctl enable caddy.service
-            systemctl enable xray.service
-
-            # 确认系统服务已创建并启动
-            echo "系统服务已创建完成。"
-            echo "Caddy 服务状态："
-            systemctl status caddy.service --no-pager || true
-            echo "Xray 服务状态："
-            systemctl status xray.service --no-pager || true
-
-            echo "服务已设置为开机自启，并已启动。"
+            show_systemd_status
             echo "你可以使用以下命令管理服务："
             echo "  启动服务: systemctl start caddy.service xray.service"
             echo "  停止服务: systemctl stop caddy.service xray.service"

--- a/service.sh
+++ b/service.sh
@@ -20,6 +20,9 @@ log_warning() {
 
 # --- Function to Start Services ---
 start_services() {
+    local start_failures=0
+    log_warning "service.sh 仅用于手动 debug/fallback；默认长期运行路径由 systemd 托管。"
+
     # Check if services are already installed
     if [ ! -f "/usr/local/bin/caddy" ] || [ ! -f "/usr/local/bin/xray" ]; then
         log_error "Xray 或 Caddy 未安装。请先运行安装脚本。"
@@ -47,11 +50,12 @@ start_services() {
     sleep 3 # Give it a moment to start or fail
 
     if ps -p $CADDY_PID > /dev/null; then
-       log_info "Caddy 服务已启动 (PID: $CADDY_PID)。日志文件: $CADDY_LOG_FILE"
+       log_info "Caddy fallback 进程已启动 (PID: $CADDY_PID)。日志文件: $CADDY_LOG_FILE"
     else
-       log_error "Caddy 服务启动失败。请检查日志: $CADDY_LOG_FILE"
+       log_error "Caddy fallback 进程启动失败。请检查日志: $CADDY_LOG_FILE"
        log_error "尝试查看 Caddy 日志尾部:"
        tail -n 20 "$CADDY_LOG_FILE" || true
+       start_failures=$((start_failures + 1))
     fi
 
     # --- Start Xray-core Service ---
@@ -82,9 +86,8 @@ start_services() {
         log_info "Xray 可执行文件权限: $(stat -c%a "$XRAY_EXE")"
     else
         log_error "Xray 可执行文件不存在: $XRAY_EXE"
-        log_error "无法启动 Xray 服务，缺少可执行文件。"
-        # 即使 Xray 启动失败，也要继续启动 Caddy 服务
-        return 0  # 返回成功代码，继续执行
+        log_error "无法启动 Xray fallback 进程，缺少可执行文件。"
+        return 1
     fi
 
     log_info "正在启动 Xray-core 服务... 日志将输出到 $XRAY_LOG_FILE"
@@ -97,11 +100,12 @@ start_services() {
     sleep 3 # Give it a moment to start or fail
 
     if ps -p $XRAY_PID > /dev/null; then
-       log_info "Xray-core 服务已启动 (PID: $XRAY_PID)。日志文件: $XRAY_LOG_FILE"
+       log_info "Xray-core fallback 进程已启动 (PID: $XRAY_PID)。日志文件: $XRAY_LOG_FILE"
     else
-       log_error "Xray-core 服务启动失败。请检查日志: $XRAY_LOG_FILE"
+       log_error "Xray-core fallback 进程启动失败。请检查日志: $XRAY_LOG_FILE"
        log_error "尝试查看 Xray 日志尾部:"
        tail -n 20 "$XRAY_LOG_FILE" || true
+       start_failures=$((start_failures + 1))
     fi
 
     # --- Show service status summary ---
@@ -131,9 +135,13 @@ start_services() {
     log_info "管理服务 (示例):"
     log_info "  要停止服务: bash service.sh stop"
     log_info "  要重启服务: bash service.sh restart"
-    log_info "  要查看状态: bash service.sh status"
-    log_info "  为确保服务稳定运行和开机自启，强烈建议将它们配置为 systemd 服务。"
+    log_info "  要查看 fallback 状态: bash service.sh status"
+    log_info "  默认长期运行请使用: systemctl status caddy.service xray.service"
     log_info "---------------------------------------------------------------------"
+
+    if [ "$start_failures" -gt 0 ]; then
+        return 1
+    fi
 }
 
 # --- Function to Stop Services ---
@@ -272,7 +280,7 @@ check_status() {
 
 # --- Main script logic ---
 if [ $# -eq 0 ]; then
-    # 默认操作是启动服务
+    # 默认操作是启动手动 fallback 进程
     start_services
 else
     # 根据命令行参数执行不同操作
@@ -291,11 +299,11 @@ else
             ;;
         *)
             echo "用法: $0 [start|stop|restart|status]"
-            echo "  默认 (无参数): 启动服务"
-            echo "  start:   启动 Caddy 和 Xray-core 服务"
-            echo "  stop:    停止 Caddy 和 Xray-core 服务"
-            echo "  restart: 重启 Caddy 和 Xray-core 服务"
-            echo "  status:  显示 Caddy 和 Xray-core 服务的状态"
+            echo "  默认 (无参数): 启动手动 fallback 进程"
+            echo "  start:   启动 Caddy 和 Xray-core fallback 进程"
+            echo "  stop:    停止 Caddy 和 Xray-core fallback 进程"
+            echo "  restart: 重启 Caddy 和 Xray-core fallback 进程"
+            echo "  status:  显示 fallback 进程状态"
             exit 1
             ;;
     esac

--- a/service.sh
+++ b/service.sh
@@ -122,10 +122,19 @@ start_services() {
         log_error "Caddy 和 Xray-core 服务似乎都启动失败了。请检查上面的日志。"
     fi
 
-    # 将PID保存到文件中，便于后续管理
+    # 仅保存仍存活的 fallback PID，避免后续误杀复用 PID 的无关进程
     mkdir -p /var/run/xray-caddy
-    echo "$CADDY_PID" > /var/run/xray-caddy/caddy.pid
-    echo "$XRAY_PID" > /var/run/xray-caddy/xray.pid
+    if ps -p "$CADDY_PID" > /dev/null 2>&1; then
+        echo "$CADDY_PID" > /var/run/xray-caddy/caddy.pid
+    else
+        rm -f /var/run/xray-caddy/caddy.pid
+    fi
+
+    if ps -p "$XRAY_PID" > /dev/null 2>&1; then
+        echo "$XRAY_PID" > /var/run/xray-caddy/xray.pid
+    else
+        rm -f /var/run/xray-caddy/xray.pid
+    fi
 
     log_info ""
     log_info "服务日志:"


### PR DESCRIPTION
## Summary
- Add installer health reporting for binary, config, systemd, listener, external HTTPS, and client-info checks.
- Move the default install path to systemd-managed Xray/Caddy services while keeping service.sh as a manual fallback.
- Update Xray KCP templates to FinalMask and harden client config generation/credential handling.

## Test plan
- [x] bash -n install.sh main.sh service.sh download.sh install_remote.sh update.sh
- [x] python3 -m json.tool cfg_tpl/xray_config.json
- [x] python3 -m json.tool cfg_tpl/xray_client.config.json
- [x] python3 -m json.tool cfg_tpl/caddy_config.json
- [x] python3 -m json.tool cfg_tpl/caddy_existing_cert_config.json
- [x] git diff --check
- [x] helper smoke tests for X25519 parsing and sed replacement escaping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 安装过程新增健康检查报告，包括配置验证、二进制检查和外部连接测试。
  * 服务现由systemd管理，提供自动启动和生命周期管理能力。

* **改进**
  * 更新了传输层配置，应用更新的加密方式。
  * 增强了错误检测和故障恢复机制。
  * 改进了密钥提取逻辑的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->